### PR TITLE
Attempt to fix niclo-requirements in VNFD.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ include ./setup.mk
 
 .PHONY: all start stop clean db-clean
 
-all: packages netsim
+all: packages netsim etsi-nfv-tree.txt etsi-nfv-tree.html etsi-nfv-swagger.json
 	if [ ! -d ncs-cdb ]; then mkdir ncs-cdb; fi
 	if [ ! -d init_data ]; then mkdir init_data; fi
 	cp init_data/* ncs-cdb/. > /dev/null 2>&1 || true
@@ -20,6 +20,7 @@ stop: netsim-stop
 clean: packages-clean netsim-clean db-clean
 	rm -rf logs/* lux_logs
 	rm -rf .bundle
+	rm -rf etsi-nfv-tree.* nfv-swagger.json
 
 db-clean:
 	rm -rf state/* ncs-cdb/*
@@ -65,5 +66,11 @@ container-test:
 	docker build -t etsi-test .
 	docker run --rm -it etsi-test
 
-nfv-swagger.json: packages/sol6/src/yang/*.yang
+etsi-nfv-swagger.json: packages/sol6/src/yang/*.yang
 	yanger -f swagger -o $@ -p packages/sol6/src/yang packages/sol6/src/yang/etsi-nfv.yang
+
+etsi-nfv-tree.txt: packages/sol6/src/yang/*.yang
+	pyang -f tree -o $@ -p packages/sol6/src/yang packages/sol6/src/yang/etsi-nfv.yang
+
+etsi-nfv-tree.html: packages/sol6/src/yang/*.yang
+	pyang -f jstree -o $@ -p packages/sol6/src/yang packages/sol6/src/yang/etsi-nfv.yang

--- a/packages/sol6/src/yang/etsi-nfv-vnf.yang
+++ b/packages/sol6/src/yang/etsi-nfv-vnf.yang
@@ -82,49 +82,19 @@ submodule etsi-nfv-vnf {
            VirtualNetworkInterfaceRequirements information element";
       }
 
-      list niclo-requirements {
-	key "id";
-	
-	leaf id {
-	  type string;
-	  description
-	    "Identifies this set of logical node requirements.";
-	  reference
-	    "GS NFV-IFA011: Section 7.1.9.6, LogicalNodeRequirements
-             information element";
+      leaf niclo-requirements {
+	type leafref {
+	  path "/nfv/vnfd/virtual-compute-descriptor/id";
 	}
-
-	list logical-node-requirement-detail {
-	  key "key";
-	  leaf key {
-	    type string;
-	  }
-	  leaf value {
-	    type string;
-	  }
-	  description
-	    "The logical node-level compute, memory and I/O
-             requirements. An array of key-value pairs that
-             articulate the deployment requirements. This could
-             include the number of CPU cores on this logical node, a
-             memory configuration specific to a logical node
-             (e.g. such as available in the Linux kernel via the
-             libnuma library) or a requirement related to the
-             association of an I/O device with the logical node.";
-	  reference
-	    "GS NFV-IFA011: Section 7.1.9.6, LogicalNodeRequirements
-             information element";
-	}
-	
-        description
-          "This identifier (couples) the CPD with any logical node I/O
-           requirements (for network devices) that may have been
-           created. Linking these attributes is necessary so that so
-           that I/O requirements that need to be articulated at the
+	description
+	  "This references (couples) the CPD with any logical node
+           I/O requirements (for network devices) that may have been
+           created. Linking these attributes is necessary so that
+           I/O requirements that need to be articulated at the
            logical node level can be associated with the network
            interface requirements associated with the CPD.";
-        reference
-          "GS NFV-IFA011: Section 7.1.6.6,
+	reference
+	  "GS NFV-IFA011: Section 7.1.6.6,
            VirtualNetworkInterfaceRequirements information element";
       }
     }

--- a/packages/sol6/src/yang/etsi-nfv-vnf.yang
+++ b/packages/sol6/src/yang/etsi-nfv-vnf.yang
@@ -83,7 +83,6 @@ submodule etsi-nfv-vnf {
       }
 
       list niclo-requirements {
-        mandatory true;
 	key "id";
 	
 	leaf id {

--- a/packages/sol6/src/yang/etsi-nfv-vnf.yang
+++ b/packages/sol6/src/yang/etsi-nfv-vnf.yang
@@ -81,14 +81,44 @@ submodule etsi-nfv-vnf {
           "GS NFV-IFA011: Section 7.1.6.6,
            VirtualNetworkInterfaceRequirements information element";
       }
-      leaf niclo-requirements {
+
+      list niclo-requirements {
         mandatory true;
-        type string; // remove once leafref is resolved.
-        //type leafref {
-          // add path statement here to logical-node-data.
-        //}
+	key "id";
+	
+	leaf id {
+	  type string;
+	  description
+	    "Identifies this set of logical node requirements.";
+	  reference
+	    "GS NFV-IFA011: Section 7.1.9.6, LogicalNodeRequirements
+             information element";
+	}
+
+	list logical-node-requirement-detail {
+	  key "key";
+	  leaf key {
+	    type string;
+	  }
+	  leaf value {
+	    type string;
+	  }
+	  description
+	    "The logical node-level compute, memory and I/O
+             requirements. An array of key-value pairs that
+             articulate the deployment requirements. This could
+             include the number of CPU cores on this logical node, a
+             memory configuration specific to a logical node
+             (e.g. such as available in the Linux kernel via the
+             libnuma library) or a requirement related to the
+             association of an I/O device with the logical node.";
+	  reference
+	    "GS NFV-IFA011: Section 7.1.9.6, LogicalNodeRequirements
+             information element";
+	}
+	
         description
-          "This references (couples) the CPD with any logical node I/O
+          "This identifier (couples) the CPD with any logical node I/O
            requirements (for network devices) that may have been
            created. Linking these attributes is necessary so that so
            that I/O requirements that need to be articulated at the

--- a/packages/sol6/src/yang/etsi-nfv-vnf.yang
+++ b/packages/sol6/src/yang/etsi-nfv-vnf.yang
@@ -87,14 +87,14 @@ submodule etsi-nfv-vnf {
 	  path "/nfv/vnfd/virtual-compute-descriptor/id";
 	}
 	description
-	  "This references (couples) the CPD with any logical node
+          "This references (couples) the CPD with any logical node
            I/O requirements (for network devices) that may have been
            created. Linking these attributes is necessary so that
            I/O requirements that need to be articulated at the
            logical node level can be associated with the network
            interface requirements associated with the CPD.";
-	reference
-	  "GS NFV-IFA011: Section 7.1.6.6,
+        reference
+          "GS NFV-IFA011: Section 7.1.6.6,
            VirtualNetworkInterfaceRequirements information element";
       }
     }


### PR DESCRIPTION
I believe that the current definition of niclo-requirements in Section 7.1.9.6 of IFA011 (v 2.5.3) is incorrect. It has been fixed in v 2.5.4. This change is for that fix.