### PR TITLE
Naming consistency and added choice in sapd

### DIFF
--- a/packages/sol6/src/yang/etsi-nfv-ns.yang
+++ b/packages/sol6/src/yang/etsi-nfv-ns.yang
@@ -147,17 +147,6 @@ submodule etsi-nfv-ns {
             "GS NFV IFA014: Section 6.2.3.2 Sapd information element";
         }
 
-        leaf virtual-link-desc {
-          type leafref {
-            path "../../virtual-link-desc/id";
-          }
-          description
-            "References the descriptor of the NS VL instance to
-             which the SAP instantiated from this SAPD connects to.";
-          reference
-            "GS NFV IFA014: Section 6.2.3.2 Sapd information element";
-        }
-
         choice associated-vl-or-cpd-id {
           leaf virtual-link-desc {
             type leafref {

--- a/packages/sol6/src/yang/etsi-nfv-ns.yang
+++ b/packages/sol6/src/yang/etsi-nfv-ns.yang
@@ -158,7 +158,17 @@ submodule etsi-nfv-ns {
             "GS NFV IFA014: Section 6.2.3.2 Sapd information element";
         }
 
-        choice associated-cpd-id {
+        choice associated-vl-or-cpd-id {
+          leaf virtual-link-desc {
+            type leafref {
+              path "../../virtual-link-desc/id";
+            }
+            description
+              "References the descriptor of the NS VL instance to
+             which the SAP instantiated from this SAPD connects to.";
+            reference
+              "GS NFV IFA014: Section 6.2.3.2 Sapd information element";
+          }
           container vnf {
             leaf vnfd-id {
               mandatory true;

--- a/packages/sol6/src/yang/etsi-nfv-vnf.yang
+++ b/packages/sol6/src/yang/etsi-nfv-vnf.yang
@@ -1269,17 +1269,17 @@ submodule etsi-nfv-vnf {
               path "../../nfv:int-virtual-link-desc/nfv:id";
             }
           }
-          container int-cpd {
+          container vdu {
             presence "Direct pointer to an intCpd";
-            leaf vdu {
+            leaf vdu-id {
               type leafref {
                 path "../../../nfv:vdu/nfv:id";
               }
               mandatory true;
             }
-            leaf cpd {
+            leaf int-cpd-id {
               type leafref {
-                path "deref(../vdu)/../nfv:int-cpd/nfv:id";
+                path "deref(../vdu-id)/../nfv:int-cpd/nfv:id";
               }
               mandatory true;
             }


### PR DESCRIPTION
Naming consistency between NSD sapd and VNFD ext-cpd, and also made the sapd
to be a choice between virtual link or vnfd-cpd. 