### PR TITLE
compiling modules

### DIFF
--- a/packages/sol6/src/Makefile
+++ b/packages/sol6/src/Makefile
@@ -6,8 +6,10 @@ include $(NCS_DIR)/src/ncs/build/include.ncs.mk
 
 SRC  = $(wildcard yang/*.yang)
 DIRS = ../load-dir
-FXS = $(DIRS)/etsi-nfv-pkg.fxs $(DIRS)/etsi-nfv-descriptors.fxs
+FXS = $(DIRS)/etsi-nfv-pkg.fxs $(DIRS)/etsi-nfv-descriptors.fxs $(DIRS)/etsi-nfv-common.fxs $(DIRS)/etsi-nfv-vnf.fxs
 
+$(DIRS)/etsi-nfv-common.fxs:
+$(DIRS)/etsi-nfv-vnf.fxs: yang/etsi-nfv-common.yang
 $(DIRS)/etsi-nfv-pkg.fxs: yang/etsi-nfv-common.yang yang/etsi-nfv-vnf.yang
 $(DIRS)/etsi-nfv-descriptors.fxs: yang/etsi-nfv-common.yang yang/etsi-nfv-vnf.yang yang/etsi-nfv-pnf.yang yang/etsi-nfv-ns.yang
 

--- a/packages/sol6/src/yang/etsi-nfv-common.yang
+++ b/packages/sol6/src/yang/etsi-nfv-common.yang
@@ -242,7 +242,7 @@ module etsi-nfv-common {
     description
       "Ephemeral type of storage.";
   }
-  
+
   /*
    * Typedefs
    */
@@ -634,17 +634,6 @@ module etsi-nfv-common {
          several VLANs. A cardinality of 0 implies that trunkMode
          is not configured for the Cp i.e. It is equivalent to
          Boolean value 'false'.";
-      reference
-        "GS NFV IFA011: Section 7.1.6.3 Cpd information element";
-    }
-
-    leaf security-group-rule-id {
-      type leafref {
-        path "../../../security-group-rule/id";
-      }
-      description
-        "Reference of the security group rules bound to this
-         CPD.";
       reference
         "GS NFV IFA011: Section 7.1.6.3 Cpd information element";
     }

--- a/packages/sol6/src/yang/etsi-nfv-vnf.yang
+++ b/packages/sol6/src/yang/etsi-nfv-vnf.yang
@@ -86,22 +86,6 @@ module etsi-nfv-vnf {
           "GS NFV-IFA011: Section 7.1.6.6,
            VirtualNetworkInterfaceRequirements information element";
       }
-
-      leaf nicio-requirements {
-        type leafref {
-          path "../../../virtual-compute-desc/id";
-        }
-        description
-          "This references (couples) the CPD with any logical node I/O
-           requirements (for network devices) that may have been
-           created. Linking these attributes is necessary so that so
-           that I/O requirements that need to be articulated at the
-           logical node level can be associated with the network
-           interface requirements associated with the CPD.";
-        reference
-          "GS NFV-IFA011: Section 7.1.6.6,
-           VirtualNetworkInterfaceRequirements information element";
-      }
     }
   }
 
@@ -259,6 +243,21 @@ module etsi-nfv-vnf {
                element.";
 	}
 	uses virtual-network-interface-requirements;
+        leaf nicio-requirements {
+          type leafref {
+            path "../../../virtual-compute-desc/id";
+          }
+          description
+            "This references (couples) the CPD with any logical node I/O
+           requirements (for network devices) that may have been
+           created. Linking these attributes is necessary so that so
+           that I/O requirements that need to be articulated at the
+           logical node level can be associated with the network
+           interface requirements associated with the CPD.";
+          reference
+            "GS NFV-IFA011: Section 7.1.6.6,
+           VirtualNetworkInterfaceRequirements information element";
+        }
 	leaf-list order {
 	  type uint32;
 	  description
@@ -279,6 +278,16 @@ module etsi-nfv-vnf {
                element.";
 	}
 	uses cmn:cpd;
+        leaf security-group-rule-id {
+          type leafref {
+            path "../../../security-group-rule/id";
+          }
+          description
+            "Reference of the security group rules bound to this
+         CPD.";
+          reference
+            "GS NFV IFA011: Section 7.1.6.3 Cpd information element";
+        }
       }
       leaf virtual-compute-desc {
 	type leafref {
@@ -1176,7 +1185,32 @@ module etsi-nfv-vnf {
 	}
       }
       uses virtual-network-interface-requirements;
+      leaf nicio-requirements {
+        type leafref {
+          path "../../virtual-compute-desc/id";
+        }
+        description
+          "This references (couples) the CPD with any logical node I/O
+           requirements (for network devices) that may have been
+           created. Linking these attributes is necessary so that so
+           that I/O requirements that need to be articulated at the
+           logical node level can be associated with the network
+           interface requirements associated with the CPD.";
+        reference
+          "GS NFV-IFA011: Section 7.1.6.6,
+           VirtualNetworkInterfaceRequirements information element";
+      }
       uses cmn:cpd;
+      leaf security-group-rule-id {
+        type leafref {
+          path "../../security-group-rule/id";
+        }
+        description
+          "Reference of the security group rules bound to this
+         CPD.";
+        reference
+          "GS NFV IFA011: Section 7.1.6.3 Cpd information element";
+      }
     }
 
     list df {
@@ -2655,4 +2689,3 @@ module etsi-nfv-vnf {
     }
   }
 }
-


### PR DESCRIPTION
I had to move the nicio-requirements and security-group-rule-id out of the groupings, 
as the relative path it relies on will be different when the grouping cpd is used in ext-cpd and and int-cpd.
